### PR TITLE
Make it work on Windows

### DIFF
--- a/pytest_mypy/collect.py
+++ b/pytest_mypy/collect.py
@@ -1,3 +1,4 @@
+import tempfile
 from typing import Any, Dict, List
 
 import pytest
@@ -96,7 +97,7 @@ def pytest_collect_file(path, parent):
 
 def pytest_addoption(parser: Parser) -> None:
     group = parser.getgroup('mypy-tests')
-    group.addoption('--mypy-testing-base', type=str, default='/tmp',
+    group.addoption('--mypy-testing-base', type=str, default=tempfile.gettempdir(),
                     help='Base directory for tests to use')
     group.addoption('--mypy-ini-file', type=str,
                     help='Which .ini file to use as a default config for tests')

--- a/pytest_mypy/tests/test-extension.yml
+++ b/pytest_mypy/tests/test-extension.yml
@@ -3,5 +3,5 @@
         # if hook works, main should contain 'reveal_type(1)'
     reveal_type: 1
     out: |
-        main:1: note: Revealed type is 'builtins.int'
+        main:1: note: Revealed type is 'Literal[1]?'
 

--- a/pytest_mypy/utils.py
+++ b/pytest_mypy/utils.py
@@ -1,11 +1,13 @@
 # Borrowed from Pew.
 # See https://github.com/berdario/pew/blob/master/pew/_utils.py#L82
+import contextlib
 import inspect
+import io
 import os
 import re
 import sys
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Iterator, List, Optional, Tuple
 
 from decorator import contextmanager
 
@@ -310,3 +312,15 @@ def cd(path):
         yield
     finally:
         os.chdir(prev_cwd)
+
+
+@contextmanager
+def capture_std_streams() -> Iterator[Tuple[io.StringIO, io.StringIO]]:
+    """Context manager to temporarily capture stdout and stderr.
+
+    Returns ``(stdout, stderr)``.
+    """
+    out = io.StringIO()
+    err = io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        yield out, err

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ dependencies = [
     'pytest',
     'mypy>=0.730',
     'decorator',
-    'capturer',
     'pyyaml'
 ]
 


### PR DESCRIPTION
Remove `capturer` dependency: use `contextlib.redirect_*` instead.
Also fixed some other minor issues

See #13 