### PR TITLE
#18 Rename filelocrepr to reprfileloc

### DIFF
--- a/pytest_mypy/item.py
+++ b/pytest_mypy/item.py
@@ -301,11 +301,11 @@ class YamlTestItem(pytest.Item):
             repr_file_location = ReprFileLocation(path=self.fspath,
                                                   lineno=self.starting_lineno + excinfo.value.lineno,
                                                   message='')
-            repr_tb_entry = TraceLastReprEntry(reprfileloc=repr_file_location,
-                                               lines=exception_repr.reprtraceback.reprentries[-1].lines[1:],
-                                               style='short',
-                                               reprlocals=None,
-                                               reprfuncargs=None)
+            repr_tb_entry = TraceLastReprEntry(exception_repr.reprtraceback.reprentries[-1].lines[1:],
+                                               None,
+                                               None,
+                                               repr_file_location,
+                                               'short')
             exception_repr.reprtraceback.reprentries = [repr_tb_entry]
             return exception_repr
         else:

--- a/pytest_mypy/item.py
+++ b/pytest_mypy/item.py
@@ -301,7 +301,7 @@ class YamlTestItem(pytest.Item):
             repr_file_location = ReprFileLocation(path=self.fspath,
                                                   lineno=self.starting_lineno + excinfo.value.lineno,
                                                   message='')
-            repr_tb_entry = TraceLastReprEntry(filelocrepr=repr_file_location,
+            repr_tb_entry = TraceLastReprEntry(reprfileloc=repr_file_location,
                                                lines=exception_repr.reprtraceback.reprentries[-1].lines[1:],
                                                style='short',
                                                reprlocals=None,


### PR DESCRIPTION
Fixes a bug introduced with `pytest >= 5.4.0` (specifically since https://github.com/pytest-dev/pytest/pull/6739) which prevented `pytest-mypy-plugins` from running.

This change might require specifying the correct version of `pytest` in dependencies, I'm not sure what the best way to handle this is.