### PR TITLE
restrict supported python version in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     # the following makes a plugin available to pytest
     entry_points={"pytest11": ["pytest-mypy-plugins = pytest_mypy_plugins.collect"]},
     install_requires=dependencies,
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Dotted inline types like `files: List[File] = []` are supported in Python 3.6 and onwards, so installing `pytest-mypy-plugins` on e.g. Python 3.5 breaks the tests. This PR prohibits installation on Python 3.5 and below.

Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>