### PR TITLE
Add `@parametrized` handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Gitter](https://badges.gitter.im/mypy-django/Lobby.svg)](https://gitter.im/mypy-django/Lobby)
 
-
 ## Installation
 
 ```bash
 pip install pytest-mypy-plugins
 ```
-
 
 ## Usage
 
@@ -20,20 +18,28 @@ Examples of a test case:
 
 ```yaml
 # typesafety/test_request.yml
--   case: request_object_has_user_of_type_auth_user_model
-    disable_cache: true
-    main: |
-        from django.http.request import HttpRequest
-        reveal_type(HttpRequest().user)  # N: Revealed type is 'myapp.models.MyUser'
-        # check that other fields work ok
-        reveal_type(HttpRequest().method)  # N: Revealed type is 'Union[builtins.str, None]'
-    files:
-        -   path: myapp/__init__.py
-        -   path: myapp/models.py
-            content: |
-                from django.db import models
-                class MyUser(models.Model):
-                    pass
+- case: request_object_has_user_of_type_auth_user_model
+  disable_cache: true
+  main: |
+    from django.http.request import HttpRequest
+    reveal_type(HttpRequest().user)  # N: Revealed type is 'myapp.models.MyUser'
+    # check that other fields work ok
+    reveal_type(HttpRequest().method)  # N: Revealed type is 'Union[builtins.str, None]'
+  files:
+    - path: myapp/__init__.py
+    - path: myapp/models.py
+      content: |
+        from django.db import models
+        class MyUser(models.Model):
+            pass
+- case: with_params
+  parametrized:
+    - val: 1
+      rt: builtins.int
+    - val: 1.0
+      rt: builtins.float
+  main: |
+    reveal_type({[ val }})  # N: Reveal type is '{{ rt }}'
 ```
 
 Running:

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -43,11 +43,11 @@ def parse_environment_variables(env_vars: List[str]) -> Dict[str, str]:
     return parsed_vars
 
 
-def parse_parametrized(params: List[Dict[str, Any]]) -> List[Mapping[str, Any]]:
+def parse_parametrized(params: List[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
     if not params:
         return [{}]
-    parsed_params = []
-    # verify param consistency
+
+    parsed_params: List[Mapping[str, Any]] = []
     known_params = None
     for idx, param in enumerate(params):
         param_keys = set(sorted(param.keys()))
@@ -59,9 +59,9 @@ def parse_parametrized(params: List[Dict[str, Any]]) -> List[Mapping[str, Any]]:
                 f'First entry is {", ".join(known_params)} but {", ".join(param_keys)} '
                 "was spotted at {idx} position",
             )
-        param.pop('__line__')
-        parsed_params.append(param)
-    return params
+        parsed_params.append({k: v for k, v in param.items() if not k.startswith("__")})
+
+    return parsed_params
 
 
 class SafeLineLoader(yaml.SafeLoader):
@@ -97,9 +97,9 @@ class YamlTestFile(pytest.File):
             for params in parametrized:
                 if params:
                     test_name_suffix = ",".join(f"{k}={v}" for k, v in params.items())
-                    test_name_suffix = f'[{test_name_suffix}]'
+                    test_name_suffix = f"[{test_name_suffix}]"
                 else:
-                    test_name_suffix = ''
+                    test_name_suffix = ""
 
                 test_name = f"{test_name_prefix}{test_name_suffix}"
                 main_file = File(path="main.py", content=pystache.render(raw_test["main"], params))

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -113,7 +113,7 @@ class YamlTestFile(pytest.File):
                 starting_lineno = raw_test["__line__"]
                 extra_environment_variables = parse_environment_variables(raw_test.get("env", []))
                 disable_cache = raw_test.get("disable_cache", False)
-                expected_output_lines = raw_test.get("out", "").split("\n")
+                expected_output_lines = pystache.render(raw_test.get("out", ""), params).split("\n")
                 additional_mypy_config = raw_test.get("mypy_config", "")
 
                 skip = self._eval_skip(str(raw_test.get("skip", "False")))

--- a/pytest_mypy_plugins/tests/test-parametrized.yml
+++ b/pytest_mypy_plugins/tests/test-parametrized.yml
@@ -26,3 +26,19 @@
 
         def test(a: Any, b: Any) -> Any:
           ...
+- case: with_out
+  parametrized:
+    - what: cat
+      rt: builtins.str
+    - what: dog
+      rt: builtins.str
+  main: |
+    animal = '{{ what }}'
+    reveal_type(animal)
+    try:
+      animal / 2
+    except Exception:
+      ...
+  out: |
+    main:2: note: Revealed type is '{{ rt }}'
+    main:4: error: Unsupported operand types for / ("str" and "int")

--- a/pytest_mypy_plugins/tests/test-parametrized.yml
+++ b/pytest_mypy_plugins/tests/test-parametrized.yml
@@ -8,3 +8,21 @@
   main: |
     a = {{ a }}
     reveal_type(a)  # N: Revealed type is '{{ revealed_type }}'
+- case: with_extra
+  parametrized:
+    - a: 2
+      b: null
+      rt: Any
+    - a: 3
+      b: 3
+      rt: Any
+  main: |
+    import foo
+    reveal_type(foo.test({{ a }}, {{ b }}))  # N: Revealed type is '{{ rt }}'
+  files:
+    - path: foo.py
+      content: |
+        from typing import Any
+
+        def test(a: Any, b: Any) -> Any:
+          ...

--- a/pytest_mypy_plugins/tests/test-parametrized.yml
+++ b/pytest_mypy_plugins/tests/test-parametrized.yml
@@ -1,0 +1,10 @@
+---
+- case: only_main
+  parametrized:
+    - a: 1
+      revealed_type: builtins.int
+    - a: 1.0
+      revealed_type: builtins.float
+  main: |
+    a = {{ a }}
+    reveal_type(a)  # N: Revealed type is '{{ revealed_type }}'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,13 @@ from setuptools import setup
 with open("README.md", "r") as f:
     readme = f.read()
 
-dependencies = ["pytest>=5.4.0", "mypy>=0.730", "decorator", "pyyaml"]
+dependencies = [
+    "pytest>=5.4.0",
+    "mypy>=0.730",
+    "decorator",
+    "pyyaml",
+    "pystache>=0.5.4",
+]
 
 setup(
     name="pytest-mypy-plugins",


### PR DESCRIPTION
This adds something similar to `@pytest.mark.parametrized`.

Summary:
- done via `pystache` to ease a burden of templating a test file content
- parameters must be consistent between each entries
- only `main` is templated, extra files are not