### PR TITLE
Remove fewer occurrences of .py when cleaning output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
     script: 'black --check pytest_mypy_plugins setup.py'
   - name: Lint with isort
     python: 3.7
-    script: 'isort --check --diff'
+    script: 'isort --check --diff .'
 
 before_install: |
   # Upgrade pip, setuptools, and wheel

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -2,14 +2,14 @@ import os
 import platform
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Mapping
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional
 
+import pystache
 import pytest
 import yaml
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Node
 from py._path.local import LocalPath
-import pystache
 
 from pytest_mypy_plugins import utils
 

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -53,7 +53,7 @@ def replace_fpath_with_module_name(line: str, rootdir: Path) -> str:
         return line
     out_fpath, res_line = line.split(":", 1)
     line = os.path.relpath(out_fpath, start=rootdir) + ":" + res_line
-    return line.strip().replace(".py", "")
+    return line.strip().replace(".py:", ":")
 
 
 class ReturnCodes:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [isort]
 include_trailing_comma = true
 multi_line_output = 3
-wrap_length = 120


### PR DESCRIPTION
resolves #35 by changing the match pattern from .py to .py: (+ ":") and replacing with ":".

Hopefully, this will match text like:

    main.py: 1

But not match text like:

> ...$HOME/**.py**env/
> .../foo **.py**i
