### PR TITLE
Add option `--mypy-only-local-stub`

### DIFF
--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -155,7 +155,7 @@ def pytest_addoption(parser: Parser) -> None:
         "Has to be top-level.",
     )
     group.addoption(
-        "--mypy-only-local-stub", 
-        action="store_true", 
+        "--mypy-only-local-stub",
+        action="store_true",
         help="mypy will ignore errors from site-packages",
     )

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -154,3 +154,8 @@ def pytest_addoption(parser: Parser) -> None:
         help="Fully qualified path to the extension hook function, in case you need custom yaml keys. "
         "Has to be top-level.",
     )
+    group.addoption(
+        "--mypy-only-local-stub", 
+        action="store_true", 
+        help="mypy will ignore errors from site-packages",
+    )

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -139,6 +139,7 @@ class YamlTestItem(pytest.Item):
         self.additional_mypy_config = mypy_config
         self.parsed_test_data = parsed_test_data
         self.same_process = self.config.option.mypy_same_process
+        self.test_only_local_stub = self.config.option.mypy_only_local_stub
 
         # config parameters
         self.root_directory = self.config.option.mypy_testing_base
@@ -296,11 +297,12 @@ class YamlTestItem(pytest.Item):
     def prepare_mypy_cmd_options(self, execution_path: Path) -> List[str]:
         mypy_cmd_options = [
             "--show-traceback",
-            "--no-silence-site-packages",
             "--no-error-summary",
             "--no-pretty",
             "--hide-error-context",
         ]
+        if not self.test_only_local_stub:
+            mypy_cmd_options.append("--no-silence-site-packages")
         if not self.disable_cache:
             mypy_cmd_options.extend(["--cache-dir", self.incremental_cache_dir])
 


### PR DESCRIPTION
This PR adds a pytest option `--mypy-only-local-stub` which will disable mypy's `--no-silence-site-packages` option.

Resolves #34 