### PR TITLE
Add missing regex dependency in setup.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip setuptools wheel
-        pip install -r dev-requirements.txt
+        pip install -e .
     - name: Run tests
-      run: pytest 
+      run: pytest
 
   lint:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = [
     "pyyaml",
     "chevron",
     "regex",
-    "dataclasses ; python_version<'3.7'"
+    "dataclasses ; python_version<'3.7'",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ dependencies = [
     "decorator",
     "pyyaml",
     "chevron",
+    "regex",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ dependencies = [
     "pyyaml",
     "chevron",
     "regex",
+    "dataclasses ; python_version<'3.7'"
 ]
 
 setup(


### PR DESCRIPTION
Do not install dev requirements when testing, there are not useful and black dependency on regex was hiding the lack of regex in setup.py

Closes #60 