### PR TITLE
Bump minimum supported mypy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 dependencies = [
     "pytest>=6.0.0",
-    "mypy>=0.790",
+    "mypy>=0.900",
     "decorator",
     "pyyaml",
     "chevron",


### PR DESCRIPTION
This PR changes minimum suported version of mypy to 0.900 based on
comments under conda-forge/staged-recipes#16453