### PR TITLE
Document expect_fail property in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ On top of that, each case must comply to following types:
 | `env`           | `Optional[Dict[str, str]]={}`                          | Environmental variables to be provided inside of test run                                                           |
 | `parametrized`  | `Optional[List[Parameter]]=[]`\*                       | List of parameters, similar to [`@pytest.mark.parametrize`](https://docs.pytest.org/en/stable/parametrize.html)     |
 | `skip`          | `str`                                                  | Expression evaluated with following globals set: `sys`, `os`, `pytest` and `platform`                               |
+| `expect_fail`   | `bool`                                                 | Mark test case as an expected failure, like [`@pytest.mark.xfail`](https://docs.pytest.org/en/stable/skipping.html) |
 | `regex`         | `str`                                                  | Allow regular expressions in comments to be matched against actual output. Defaults to "no", i.e. matches full text.|
 
 (*) Appendix to **pseudo** types used above:


### PR DESCRIPTION
This PR adds a row describing `expect_fail ` to property table in README.md. 

![updated-property-table](https://user-images.githubusercontent.com/1554276/136669299-fb861a9c-e6bd-40f1-8e4e-ea38a60b2c1e.png)
