### PR TITLE
Update build status badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # pytest plugin for testing mypy types, stubs, and plugins
 
-[![Build Status](https://travis-ci.org/typeddjango/pytest-mypy-plugins.svg?branch=master)](https://travis-ci.org/typeddjango/pytest-mypy-plugins)
+[![Tests Status](https://github.com/typeddjango/pytest-mypy-plugins/actions/workflows/test.yml/badge.svg)](https://github.com/typeddjango/pytest-mypy-plugins/actions/workflows/test.yml)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Gitter](https://badges.gitter.im/mypy-django/Lobby.svg)](https://gitter.im/mypy-django/Lobby)
 


### PR DESCRIPTION
Currently it points to no longer used travis-ci. This PR changes it to GitHub test workflow. After this change README  header will look like

![image](https://user-images.githubusercontent.com/1554276/136691500-21e4271b-4561-4efc-88b1-a0c348c7fc59.png)


with badge link pointing to https://github.com/typeddjango/pytest-mypy-plugins/actions/workflows/test.yml