### PR TITLE
Fail runtest early if temp directory failed

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -230,8 +230,14 @@ class YamlTestItem(pytest.Item):
         try:
             temp_dir = tempfile.TemporaryDirectory(prefix="pytest-mypy-", dir=self.root_directory)
 
+        except (FileNotFoundError, PermissionError, NotADirectoryError) as e:
+
+            raise TypecheckAssertionError(
+                error_message=f"Testing base directory {self.root_directory} must exist and be writable"
+            ) from e
+
+        try:
             execution_path = Path(temp_dir.name)
-            assert execution_path.exists()
 
             with utils.cd(execution_path):
                 # extension point for derived packages


### PR DESCRIPTION
This PR separates creation of the temporary directory in `runtests` from actual test run and allows us to fail early and predictably when temporary directory cannot be created.

If this PR is merged, invalid `--mypy-testing-base` will result in errors of the following form, for each test case:

```
________________________________________________________________________ fail_if_message_from_outdoes_not_match ________________________________________________________________________
pytest_mypy_plugins/item.py:231: in runtest
    temp_dir = tempfile.TemporaryDirectory(prefix="pytest-mypy-", dir=self.root_directory)
/usr/lib/python3.9/tempfile.py:918: in __init__
    self.name = mkdtemp(suffix, prefix, dir)
/usr/lib/python3.9/tempfile.py:498: in mkdtemp
    _os.mkdir(file, 0o700)
E   NotADirectoryError: [Errno 20] Not a directory: '/tmp/foo/pytest-mypy-wxqz9l5b'

The above exception was the direct cause of the following exception:
/path/to/ytest-mypy-plugins/pytest_mypy_plugins/tests/test-simple-cases.yml:100: 
E   pytest_mypy_plugins.utils.TypecheckAssertionError: Testing base directory /tmp/foo must exist and be writable

```

Resolves #86