### PR TITLE
Update path argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip setuptools wheel
+        pip install -U "pytest==${{ matrix.pytest-version }}"
         pip install -e .
     - name: Run tests
       run: pytest
@@ -42,7 +43,6 @@ jobs:
       run: |
         pip install -U pip setuptools wheel
         pip install -r dev-requirements.txt
-        pip install -U ${{ matrix.pytest-version }}
     - name: Run linters
       run: |
         mypy .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip setuptools wheel
-        pip install -U "pytest${{ matrix.pytest-version }}"
         pip install -e .
+        # Force correct `pytest` version for different envs:
+        pip install -U "pytest${{ matrix.pytest-version }}"
     - name: Run tests
       run: pytest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        pytest-version: ["~=6.2", "7.0.0rc1"]  # TODO: enable `~=7.0`
+        pytest-version: ["~=6.2", "==7.0.0rc1"]  # TODO: enable `~=7.0`
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U pip setuptools wheel
-        pip install -U "pytest==${{ matrix.pytest-version }}"
+        pip install -U "pytest${{ matrix.pytest-version }}"
         pip install -e .
     - name: Run tests
       run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        pytest-version: ["6.2.5", "7.0.0rc1"]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,6 +42,7 @@ jobs:
       run: |
         pip install -U pip setuptools wheel
         pip install -r dev-requirements.txt
+        pip install -U ${{ matrix.pytest-version }}
     - name: Run linters
       run: |
         mypy .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        pytest-version: ["6.2.5", "7.0.0rc1"]
+        pytest-version: ["~=6.2", "7.0.0rc1"]  # TODO: enable `~=7.0`
 
     steps:
     - uses: actions/checkout@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,5 @@ black
 isort
 types-decorator
 types-PyYAML
+types-setuptools
 -e .

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -158,7 +158,6 @@ if pkg_resources.parse_version(pytest.__version__) >= pkg_resources.parse_versio
             return YamlTestFile.from_parent(parent, path=file_path, fspath=None)
         return None
 
-
 else:
 
     def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:  # type: ignore[misc]

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -3,16 +3,7 @@ import pathlib
 import platform
 import sys
 import tempfile
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Set,
-)
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional, Set
 
 import pkg_resources
 import pytest

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -151,18 +151,18 @@ class YamlTestFile(pytest.File):
         return eval(skip_if, {"sys": sys, "os": os, "pytest": pytest, "platform": platform})
 
 
-if pkg_resources.parse_version(pytest.__version__) < pkg_resources.parse_version("7.0.0rc1"):
+if pkg_resources.parse_version(pytest.__version__) >= pkg_resources.parse_version("7.0.0rc1"):
 
-    def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:
-        if path.ext in {".yaml", ".yml"} and path.basename.startswith(("test-", "test_")):
-            return YamlTestFile.from_parent(parent, fspath=path)
+    def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> Optional[YamlTestFile]:
+        if file_path.suffix in {".yaml", ".yml"} and file_path.name.startswith(("test-", "test_")):
+            return YamlTestFile.from_parent(parent, path=file_path, fspath=None)
         return None
 
 else:
 
-    def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> Optional[YamlTestFile]:
-        if file_path.suffix in {".yaml", ".yml"} and file_path.name.startswith(("test-", "test_")):
-            return YamlTestFile.from_parent(parent, path=file_path)
+    def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:  # type: ignore[misc]
+        if path.ext in {".yaml", ".yml"} and path.basename.startswith(("test-", "test_")):
+            return YamlTestFile.from_parent(parent, fspath=path)
         return None
 
 

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -158,6 +158,7 @@ if pkg_resources.parse_version(pytest.__version__) >= pkg_resources.parse_versio
             return YamlTestFile.from_parent(parent, path=file_path, fspath=None)
         return None
 
+
 else:
 
     def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:  # type: ignore[misc]

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -1,9 +1,20 @@
 import os
+import pathlib
 import platform
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional, Set
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Set,
+)
 
+import pkg_resources
 import pytest
 import yaml
 from _pytest.config.argparsing import Parser
@@ -76,7 +87,9 @@ class YamlTestFile(pytest.File):
     def collect(self) -> Iterator["YamlTestItem"]:
         from pytest_mypy_plugins.item import YamlTestItem
 
-        parsed_file = yaml.load(stream=self.fspath.read_text("utf8"), Loader=SafeLineLoader)
+        # To support both Pytest 6.x and 7.x
+        path = getattr(self, "path", None) or getattr(self, "fspath")
+        parsed_file = yaml.load(stream=path.read_text("utf8"), Loader=SafeLineLoader)
         if parsed_file is None:
             return
 
@@ -138,10 +151,19 @@ class YamlTestFile(pytest.File):
         return eval(skip_if, {"sys": sys, "os": os, "pytest": pytest, "platform": platform})
 
 
-def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:
-    if path.ext in {".yaml", ".yml"} and path.basename.startswith(("test-", "test_")):
-        return YamlTestFile.from_parent(parent, fspath=path)
-    return None
+if pkg_resources.parse_version(pytest.__version__) < pkg_resources.parse_version("7.0.0rc1"):
+
+    def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:
+        if path.ext in {".yaml", ".yml"} and path.basename.startswith(("test-", "test_")):
+            return YamlTestFile.from_parent(parent, fspath=path)
+        return None
+
+else:
+
+    def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> Optional[YamlTestFile]:
+        if file_path.suffix in {".yaml", ".yml"} and file_path.name.startswith(("test-", "test_")):
+            return YamlTestFile.from_parent(parent, path=file_path)
+        return None
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -5,7 +5,17 @@ import sys
 import tempfile
 from configparser import ConfigParser
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    no_type_check,
+)
 
 import py
 import pytest
@@ -346,8 +356,11 @@ class YamlTestItem(pytest.Item):
         else:
             return super().repr_failure(excinfo, style="native")
 
-    def reportinfo(self) -> Tuple[Union[py.path.local, str], Optional[int], str]:
-        return self.fspath, None, self.name
+    @no_type_check
+    def reportinfo(self) -> Tuple[Union[py.path.local, Path, str], Optional[int], str]:
+        # To support both Pytest 6.x and 7.x
+        path = getattr(self, "path", None) or getattr(self, "fspath")
+        return path, None, self.name
 
     def _collect_python_path(
         self,


### PR DESCRIPTION
This PR introduces compatibility with pytest 7.0.0rc1.  As described [in the link](https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path) included in the original issue. `fspath` with `LocalPath` is deprecated in favor of `path` with  `pathlib.Path`.


Closes #88