### PR TITLE
Move isort config to pyproject.toml and add black profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,4 @@ jobs:
       run: |
         mypy .
         black --check pytest_mypy_plugins setup.py
-        isort --profile=black --check --diff .
+        isort --check --diff .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [tool.black]
 line-length = 120
+
+[tool.isort]
+include_trailing_comma = true
+multi_line_output = 3
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[isort]
-include_trailing_comma = true
-multi_line_output = 3


### PR DESCRIPTION
This PR:

- Removes profile=black option for isort from CI and adds it to respective configuration
- Moves isort config into `pyproject.toml` and drops `setup.cfg`.

## Reasons

Currently isort's `--profile=black` is used only in CI, which means that you have to remember do the same locally (which I personally forgot).  This can lead to situations where `isort` doesn't detect any problems locally (if profile is accidentally committed) but fails in CI.

Additionally, isort recommends `pyproject.toml` for storing configuration and `setup.cfg` is not used for anything else (other dev tool configs could be migrated as well).


