### PR TITLE
Fix possible hanging while comparing regex

### DIFF
--- a/pytest_mypy_plugins/tests/test-regex_assertions.yml
+++ b/pytest_mypy_plugins/tests/test-regex_assertions.yml
@@ -15,6 +15,20 @@
   out: |
     main:2: note: .*str.*
 
+- case: regex_with_out_does_not_hang
+  expect_fail: yes
+  regex: yes
+  main: |
+    'abc'.split(4)
+  out: |
+    main:1: error: Argument 1 to "split" of "str" has incompatible type "int"; expected "Optional[str]"
+
+- case: regex_with_comment_does_not_hang
+  expect_fail: yes
+  regex: yes
+  main: |
+    a = 'abc'.split(4)  # E: Argument 1 to "split" of "str" has incompatible type "int"; expected "Optional[str]"
+
 - case: expected_single_message_regex
   regex: no
   main: |
@@ -34,7 +48,7 @@
     a = 'hello'
     reveal_type(a)  # N: .*str.*
 
-- case: regext_does_not_match
+- case: regex_does_not_match
   expect_fail: yes
   regex: no
   main: |

--- a/pytest_mypy_plugins/utils.py
+++ b/pytest_mypy_plugins/utils.py
@@ -144,6 +144,8 @@ def _add_aligned_message(s1: str, s2: str, error_message: str) -> str:
 
     error_message += "Alignment of first line difference:\n"
 
+    assert s1 != s2
+
     trunc = False
     while s1[:30] == s2[:30]:
         s1 = s1[10:]
@@ -260,7 +262,9 @@ def assert_expected_matched_actual(expected: List[OutputMatcher], actual: List[s
             format_error_lines(actual_message_lines), format_error_lines(expected_message_lines)
         )
 
-        if (
+        if expected_line and expected_line.regex:
+            error_message += "The actual output does not match the expected regex."
+        elif (
             first_diff_actual is not None
             and first_diff_expected is not None
             and (


### PR DESCRIPTION
Hi! I'm using this plugin since a few days and this is great work!

I'm opening a PR to fix #95.
I encountered the same issue, and although it's not a big deal, I thought I might as well fix it. :)

The issue happens when the string used for the regex is equals to the output string, but the regex itself does not match the output string. In such case, the `assert_expected_matched_actual()` function tries to find and display the difference (because the two lines do not match), but can't find one (because the two string are equal) and thus fall into an infinite loop.

I would argue that it does not make sense to display difference of a regex with a string. For example, comparing the string `Argument 1 to "split" of "str" has incompatible type "int"` with regex `Argument 1 to ".*" of ".*" has incompatible type "float"` will align difference on `.*` while it's valid (difference should be on `float`).

For this reason, I removed the alignment message when using a expected regex and instead display an explicit message explaining the failure. Consequently, `_add_aligned_message()` is no longer called when two strings are equals and won't hang forever.

Thoughts?