### PR TITLE
Fix compatibility with pytest 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.10.1
+
+### Bugfixes
+
+- Fixes compatibility with pytest 7.2, broken due to a private import from
+  `py._path`.
 
 ## Version 1.10.0
 

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -6,11 +6,11 @@ import tempfile
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional, Set
 
 import pkg_resources
+import py.path
 import pytest
 import yaml
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Node
-from py._path.local import LocalPath
 
 from pytest_mypy_plugins import utils
 
@@ -151,7 +151,7 @@ if pkg_resources.parse_version(pytest.__version__) >= pkg_resources.parse_versio
 
 else:
 
-    def pytest_collect_file(path: LocalPath, parent: Node) -> Optional[YamlTestFile]:  # type: ignore[misc]
+    def pytest_collect_file(path: py.path.local, parent: Node) -> Optional[YamlTestFile]:  # type: ignore[misc]
         if path.ext in {".yaml", ".yml"} and path.basename.startswith(("test-", "test_")):
             return YamlTestFile.from_parent(parent, fspath=path)
         return None


### PR DESCRIPTION
With pytest 7.2, the remaining parts of the "py.path" library got vendored, to get rid of the dependency: https://github.com/pytest-dev/pytest/pull/10396

However, this breaks due to pytest_mypy_plugins importing private API:

    File ".../pytest_mypy_plugins/collect.py", line 13, in <module>
        from py._path.local import LocalPath
    ModuleNotFoundError: No module named 'py._path'; 'py' is not a package

Use py.path.local instead (the public name of the same type), which is part of the shim included in pytest.