### PR TITLE
Add requirements.txt to sdist package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Version history
 
 
+## WIP
+
+### Bugfixes
+
+- Add `requirements.txt` to `sdist` package
+
+
 ## 2.0.0
 
 ### Features

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include mypy.ini
 include pytest.ini
+include requirements.txt
 graft pytest_mypy_plugins/tests


### PR DESCRIPTION
This will allow downstream to make sure all requirements for testing are installed.