### PR TITLE
Add tox.ini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## WIP
 
+### Features
+
+- Add `tox.ini` file
+
 ### Bugfixes
 
 - Add `requirements.txt` to `sdist` package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include mypy.ini
 include pytest.ini
 include requirements.txt
+include tox.ini
 graft pytest_mypy_plugins/tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[testenv]
+deps =
+    -rrequirements.txt
+commands =
+    python -m pytest {posargs}


### PR DESCRIPTION
A minimal tox.ini file.  It will allow fully automatic packaging and testing of `pytest-mypy-plugins` package for OpenIndiana.

Thank you.

PS: I do NOT need new `pytest-mypy-plugins` release with these testing related improvements only.  Thanks.