### PR TITLE
Skip templating `mypy_config` if no placeholders exist

### DIFF
--- a/pytest_mypy_plugins/tests/test-parametrized.yml
+++ b/pytest_mypy_plugins/tests/test-parametrized.yml
@@ -46,6 +46,15 @@
     main:2: note: Revealed type is "{{ rt }}"
     main:4: error: Unsupported operand types for / ("str" and "int")  [operator]
 
+- case: parametrized_can_skip_mypy_config_section
+  parametrized:
+    - val: False
+    - val: True
+  mypy_config: |
+    hide_error_codes = True
+  main: |
+    a = {{ val }}
+    a.lower()  # E: "bool" has no attribute "lower"
 
 - case: with_mypy_config
   parametrized:

--- a/pytest_mypy_plugins/utils.py
+++ b/pytest_mypy_plugins/utils.py
@@ -354,6 +354,9 @@ def extract_output_matchers_from_out(out: str, params: Mapping[str, Any], regex:
 
 
 def render_template(template: str, data: Mapping[str, Any]) -> str:
+    if jinja2.defaults.VARIABLE_START_STRING not in template:
+        return template
+
     t: jinja2.environment.Template = _rendering_env.from_string(template)
     return t.render({k: v if v is not None else "None" for k, v in data.items()})
 


### PR DESCRIPTION
The solution to `if-return` on the `render_template` was selected, as the shortest one (vs modifying the `pytest_mypy_plugins/collect.py` file)