### PR TITLE
Ease testing of local stubs by extending "MYPYPATH"

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -391,5 +391,7 @@ class YamlTestItem(pytest.Item):
         if mypy_path_key:
             mypy_path_parts.append(maybe_to_abspath(mypy_path_key, rootdir))
             mypy_path_parts.append(mypy_path_key)
+        if rootdir:
+            mypy_path_parts.append(str(rootdir))
 
         self.environment_variables["MYPYPATH"] = ":".join(mypy_path_parts)


### PR DESCRIPTION
Hi!

I would like to propose a fix for #17.

I'm using a stub file and I noticed that `pytest-mypy-plugins` did not work well in the following scenarios:
- Installing a local library with `pip install -e .`
- Running `pytest` without prior installation of the local library
- Updating the local stub file after installation with `pip intall .`

I think possible workarounds have been implemented (like importing `mypy_path` and `MYPYPATH`), but they don't seem to work out of the box. Any reason not to automatically add the project sources to paths searched by Mypy?