### PR TITLE
Fix "FileNotFoundError" due to "schema.json" not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=dependencies,
     python_requires=">=3.8",
     package_data={
-        "pytest_mypy_plugins": ["py.typed"],
+        "pytest_mypy_plugins": ["py.typed", "schema.json"],
     },
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Fix #131.

```shell
$ ls /home/delgan/pytest-mypy-plugins/env/lib/python3.11/site-packages/pytest_mypy_plugins/
collect.py  configs.py  __init__.py  item.py  __pycache__  py.typed  schema.json  utils.py
```

The `"schema.json"` file was missing prior to this PR.