### PR TITLE
Extract some code from yaml test item

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -261,15 +261,15 @@ class YamlTestItem(pytest.Item):
             ) from e
 
         try:
-            execution_path = Path(temp_dir.name)
+            # extension point for derived packages
+            if (
+                hasattr(self.config.option, "mypy_extension_hook")
+                and self.config.option.mypy_extension_hook is not None
+            ):
+                self.execute_extension_hook()
 
+            execution_path = Path(temp_dir.name)
             with utils.cd(execution_path):
-                # extension point for derived packages
-                if (
-                    hasattr(self.config.option, "mypy_extension_hook")
-                    and self.config.option.mypy_extension_hook is not None
-                ):
-                    self.execute_extension_hook()
 
                 # start from main.py
                 main_file = str(execution_path / "main.py")

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -76,7 +76,7 @@ class ReturnCodes:
     FATAL_ERROR = 2
 
 
-def run_mypy_typechecking(cmd_options: List[str], stdout: TextIO, stderr: TextIO) -> Optional[Union[str, int]]:
+def run_mypy_typechecking(cmd_options: List[str], stdout: TextIO, stderr: TextIO) -> int:
     fscache = FileSystemCache()
     sources, options = process_options(cmd_options, fscache=fscache)
 
@@ -100,7 +100,16 @@ def run_mypy_typechecking(cmd_options: List[str], stdout: TextIO, stderr: TextIO
         build.build(sources, options, flush_errors=flush_errors, fscache=fscache, stdout=stdout, stderr=stderr)
 
     except SystemExit as sysexit:
-        return sysexit.code
+        # The code to a SystemExit is optional
+        # From python docs, if the code is None then the exit code is 0
+        # Otherwise if the code is not an integer the exit code is 1
+        code = sysexit.code
+        if code is None:
+            code = 0
+        elif not isinstance(code, int):
+            code = 1
+
+        return code
     finally:
         fscache.flush()
 

--- a/pytest_mypy_plugins/utils.py
+++ b/pytest_mypy_plugins/utils.py
@@ -1,8 +1,6 @@
 # Borrowed from Pew.
 # See https://github.com/berdario/pew/blob/master/pew/_utils.py#L82
-import contextlib
 import inspect
-import io
 import os
 import re
 import sys


### PR DESCRIPTION
Hello,

I have some time to make https://github.com/typeddjango/pytest-mypy-plugins/issues/144 happen (and [the need](https://github.com/delfick/extended-mypy-django-plugin) for this functionality).

I haven't got far into working out exactly how I'll make it happen, but I do believe it'll be easier if `YamlTestItem` is broken up a bit.

This PR is a refactor do do that. It should be a pure refactor and I believe the only real change is I do move `execute_extension_hook` to before the `execution_path` is created, as it currently does not know about that folder.

I want to make sure I'm not gonna be treading on any toes before going too far down this path!

This PR is best seen one commit at a time.