### PR TITLE
Delegate interpreting the yaml away from collection

### DIFF
--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -1,93 +1,16 @@
-import json
-import os
 import pathlib
-import platform
-import sys
 import tempfile
-from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Hashable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Set,
-)
+from typing import Any, Dict, Hashable, Iterator, List, Mapping, Optional
 
-import jsonschema
 import pytest
 import yaml
 from _pytest.config.argparsing import Parser
 from _pytest.nodes import Node
 
-from pytest_mypy_plugins import utils
+from .definition import File, ItemDefinition
 
-if TYPE_CHECKING:
-    from pytest_mypy_plugins.item import YamlTestItem
-
-
-@dataclass
-class File:
-    path: str
-    content: str
-
-
-def validate_schema(data: Any, *, is_closed: bool = False) -> None:
-    """Validate the schema of the file-under-test."""
-    # Unfortunately, yaml.safe_load() returns Any,
-    # so we make our intention explicit here.
-    if not isinstance(data, list):
-        raise TypeError(f"Test file has to be YAML list, got {type(data)!r}.")
-
-    schema = json.loads((pathlib.Path(__file__).parent / "schema.json").read_text("utf8"))
-    schema["items"]["properties"]["__line__"] = {
-        "type": "integer",
-        "description": "Line number where the test starts (`pytest-mypy-plugins` internal)",
-    }
-    schema["items"]["additionalProperties"] = not is_closed
-
-    jsonschema.validate(instance=data, schema=schema)
-
-
-def parse_test_files(test_files: List[Dict[str, Any]]) -> List[File]:
-    files: List[File] = []
-    for test_file in test_files:
-        path = test_file.get("path", "main.py")
-        file = File(path=path, content=test_file.get("content", ""))
-        files.append(file)
-    return files
-
-
-def parse_environment_variables(env_vars: List[str]) -> Dict[str, str]:
-    parsed_vars: Dict[str, str] = {}
-    for env_var in env_vars:
-        name, _, value = env_var.partition("=")
-        parsed_vars[name] = value
-    return parsed_vars
-
-
-def parse_parametrized(params: List[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
-    if not params:
-        return [{}]
-
-    parsed_params: List[Mapping[str, Any]] = []
-    known_params: Optional[Set[str]] = None
-    for idx, param in enumerate(params):
-        param_keys = set(sorted(param.keys()))
-        if not known_params:
-            known_params = param_keys
-        elif known_params.intersection(param_keys) != known_params:
-            raise ValueError(
-                "All parametrized entries must have same keys."
-                f'First entry is {", ".join(known_params)} but {", ".join(param_keys)} '
-                "was spotted at {idx} position",
-            )
-        parsed_params.append({k: v for k, v in param.items() if not k.startswith("__")})
-
-    return parsed_params
+# For backwards compatibility reasons this reference stays here
+File = File
 
 
 class SafeLineLoader(yaml.SafeLoader):
@@ -103,74 +26,28 @@ class SafeLineLoader(yaml.SafeLoader):
 
 
 class YamlTestFile(pytest.File):
-    def collect(self) -> Iterator["YamlTestItem"]:
-        from pytest_mypy_plugins.item import YamlTestItem
-
-        parsed_file = yaml.load(stream=self.path.read_text("utf8"), Loader=SafeLineLoader)
+    @classmethod
+    def read_yaml_file(cls, path: pathlib.Path) -> List[Mapping[str, Any]]:
+        parsed_file = yaml.load(stream=path.read_text("utf8"), Loader=SafeLineLoader)
         if parsed_file is None:
-            return
+            return []
 
-        validate_schema(parsed_file, is_closed=self.config.option.mypy_closed_schema)
-
+        # Unfortunately, yaml.safe_load() returns Any,
+        # so we make our intention explicit here.
         if not isinstance(parsed_file, list):
             raise ValueError(f"Test file has to be YAML list, got {type(parsed_file)!r}.")
 
-        for raw_test in parsed_file:
-            test_name_prefix = raw_test["case"]
-            if " " in test_name_prefix:
-                raise ValueError(f"Invalid test name {test_name_prefix!r}, only '[a-zA-Z0-9_]' is allowed.")
-            else:
-                parametrized = parse_parametrized(raw_test.get("parametrized", []))
+        return parsed_file
 
-            for params in parametrized:
-                if params:
-                    test_name_suffix = ",".join(f"{k}={v}" for k, v in params.items())
-                    test_name_suffix = f"[{test_name_suffix}]"
-                else:
-                    test_name_suffix = ""
+    def collect(self) -> Iterator[pytest.Item]:
+        is_closed = self.config.option.mypy_closed_schema
+        parsed_file = self.read_yaml_file(self.path)
 
-                test_name = f"{test_name_prefix}{test_name_suffix}"
-                main_content = utils.render_template(template=raw_test["main"], data=params)
-                main_file = File(path="main.py", content=main_content)
-                test_files = [main_file] + parse_test_files(raw_test.get("files", []))
-                expect_fail = raw_test.get("expect_fail", False)
-                regex = raw_test.get("regex", False)
-
-                expected_output = []
-                for test_file in test_files:
-                    output_lines = utils.extract_output_matchers_from_comments(
-                        test_file.path, test_file.content.split("\n"), regex=regex
-                    )
-                    expected_output.extend(output_lines)
-
-                starting_lineno = raw_test["__line__"]
-                extra_environment_variables = parse_environment_variables(raw_test.get("env", []))
-                disable_cache = raw_test.get("disable_cache", False)
-                expected_output.extend(
-                    utils.extract_output_matchers_from_out(raw_test.get("out", ""), params, regex=regex)
-                )
-                additional_mypy_config = utils.render_template(template=raw_test.get("mypy_config", ""), data=params)
-
-                skip = self._eval_skip(str(raw_test.get("skip", "False")))
-                if not skip:
-                    yield YamlTestItem.from_parent(
-                        self,
-                        name=test_name,
-                        files=test_files,
-                        starting_lineno=starting_lineno,
-                        environment_variables=extra_environment_variables,
-                        disable_cache=disable_cache,
-                        expected_output=expected_output,
-                        parsed_test_data=raw_test,
-                        mypy_config=additional_mypy_config,
-                        expect_fail=expect_fail,
-                    )
-
-    def _eval_skip(self, skip_if: str) -> bool:
-        return eval(skip_if, {"sys": sys, "os": os, "pytest": pytest, "platform": platform})
+        for test in ItemDefinition.from_yaml(parsed_file, is_closed=is_closed):
+            yield test.pytest_item(self)
 
 
-def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> Optional[YamlTestFile]:
+def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> Optional[pytest.Collector]:
     if file_path.suffix in {".yaml", ".yml"} and file_path.name.startswith(("test-", "test_")):
         return YamlTestFile.from_parent(parent, path=file_path)
     return None

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 import jsonschema
-import py.path
 import pytest
 import yaml
 from _pytest.config.argparsing import Parser
@@ -173,7 +172,7 @@ class YamlTestFile(pytest.File):
 
 def pytest_collect_file(file_path: pathlib.Path, parent: Node) -> Optional[YamlTestFile]:
     if file_path.suffix in {".yaml", ".yml"} and file_path.name.startswith(("test-", "test_")):
-        return YamlTestFile.from_parent(parent, path=file_path, fspath=None)
+        return YamlTestFile.from_parent(parent, path=file_path)
     return None
 
 

--- a/pytest_mypy_plugins/definition.py
+++ b/pytest_mypy_plugins/definition.py
@@ -159,7 +159,14 @@ class ItemDefinition:
 
     @property
     def _skipped(self) -> bool:
-        return eval(str(self.skip), {"sys": sys, "os": os, "pytest": pytest, "platform": platform})
+        if isinstance(self.skip, bool):
+            return self.skip
+        elif self.skip == "True":
+            return True
+        elif self.skip == "False":
+            return False
+        else:
+            return eval(self.skip, {"sys": sys, "os": os, "pytest": pytest, "platform": platform})
 
     @property
     def test_name(self) -> str:

--- a/pytest_mypy_plugins/definition.py
+++ b/pytest_mypy_plugins/definition.py
@@ -1,0 +1,144 @@
+import dataclasses
+import json
+import os
+import pathlib
+import platform
+import sys
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Set
+
+import jsonschema
+import pytest
+
+from . import utils
+
+
+@dataclass
+class File:
+    path: str
+    content: str
+
+
+def validate_schema(data: List[Mapping[str, Any]], *, is_closed: bool = False) -> None:
+    """Validate the schema of the file-under-test."""
+    schema = json.loads((pathlib.Path(__file__).parent / "schema.json").read_text("utf8"))
+    schema["items"]["properties"]["__line__"] = {
+        "type": "integer",
+        "description": "Line number where the test starts (`pytest-mypy-plugins` internal)",
+    }
+    schema["items"]["additionalProperties"] = not is_closed
+
+    jsonschema.validate(instance=data, schema=schema)
+
+
+def parse_test_files(test_files: List[Dict[str, Any]]) -> List[File]:
+    files: List[File] = []
+    for test_file in test_files:
+        path = test_file.get("path", "main.py")
+        file = File(path=path, content=test_file.get("content", ""))
+        files.append(file)
+    return files
+
+
+def parse_environment_variables(env_vars: List[str]) -> Dict[str, str]:
+    parsed_vars: Dict[str, str] = {}
+    for env_var in env_vars:
+        name, _, value = env_var.partition("=")
+        parsed_vars[name] = value
+    return parsed_vars
+
+
+def parse_parametrized(params: List[Mapping[str, Any]]) -> List[Mapping[str, Any]]:
+    if not params:
+        return [{}]
+
+    parsed_params: List[Mapping[str, Any]] = []
+    known_params: Optional[Set[str]] = None
+    for idx, param in enumerate(params):
+        param_keys = set(sorted(param.keys()))
+        if not known_params:
+            known_params = param_keys
+        elif known_params.intersection(param_keys) != known_params:
+            raise ValueError(
+                "All parametrized entries must have same keys."
+                f'First entry is {", ".join(known_params)} but {", ".join(param_keys)} '
+                "was spotted at {idx} position",
+            )
+        parsed_params.append({k: v for k, v in param.items() if not k.startswith("__")})
+
+    return parsed_params
+
+
+@dataclasses.dataclass
+class ItemDefinition:
+    """
+    A dataclass representing a single test in the yaml file
+    """
+
+    make_pytest_item: Callable[[pytest.Collector], pytest.Item]
+
+    @classmethod
+    def from_yaml(cls, data: List[Mapping[str, Any]], *, is_closed: bool = False) -> Iterator["ItemDefinition"]:
+        from pytest_mypy_plugins.item import YamlTestItem
+
+        validate_schema(data, is_closed=is_closed)
+
+        for raw_test in data:
+            test_name_prefix = raw_test["case"]
+            if " " in test_name_prefix:
+                raise ValueError(f"Invalid test name {test_name_prefix!r}, only '[a-zA-Z0-9_]' is allowed.")
+            else:
+                parametrized = parse_parametrized(raw_test.get("parametrized", []))
+
+            for params in parametrized:
+                if params:
+                    test_name_suffix = ",".join(f"{k}={v}" for k, v in params.items())
+                    test_name_suffix = f"[{test_name_suffix}]"
+                else:
+                    test_name_suffix = ""
+
+                test_name = f"{test_name_prefix}{test_name_suffix}"
+                main_content = utils.render_template(template=raw_test["main"], data=params)
+                main_file = File(path="main.py", content=main_content)
+                test_files = [main_file] + parse_test_files(raw_test.get("files", []))
+                expect_fail = raw_test.get("expect_fail", False)
+                regex = raw_test.get("regex", False)
+
+                expected_output = []
+                for test_file in test_files:
+                    output_lines = utils.extract_output_matchers_from_comments(
+                        test_file.path, test_file.content.split("\n"), regex=regex
+                    )
+                    expected_output.extend(output_lines)
+
+                starting_lineno = raw_test["__line__"]
+                extra_environment_variables = parse_environment_variables(raw_test.get("env", []))
+                disable_cache = raw_test.get("disable_cache", False)
+                expected_output.extend(
+                    utils.extract_output_matchers_from_out(raw_test.get("out", ""), params, regex=regex)
+                )
+                additional_mypy_config = utils.render_template(template=raw_test.get("mypy_config", ""), data=params)
+
+                skip = cls._eval_skip(str(raw_test.get("skip", "False")))
+                if not skip:
+                    yield cls(
+                        make_pytest_item=lambda parent: YamlTestItem.from_parent(
+                            parent,
+                            name=test_name,
+                            files=test_files,
+                            starting_lineno=starting_lineno,
+                            environment_variables=extra_environment_variables,
+                            disable_cache=disable_cache,
+                            expected_output=expected_output,
+                            parsed_test_data=raw_test,
+                            mypy_config=additional_mypy_config,
+                            expect_fail=expect_fail,
+                        )
+                    )
+
+    @classmethod
+    def _eval_skip(cls, skip_if: str) -> bool:
+        return eval(skip_if, {"sys": sys, "os": os, "pytest": pytest, "platform": platform})
+
+    def pytest_item(self, parent: pytest.Collector) -> pytest.Item:
+        return self.make_pytest_item(parent)

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -8,7 +8,6 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TextIO, Tuple, Union
 
-import py
 import pytest
 from _pytest._code import ExceptionInfo
 from _pytest._code.code import ReprEntry, ReprFileLocation, TerminalRepr
@@ -445,18 +444,18 @@ class YamlTestItem(pytest.Item):
     def repr_failure(
         self, excinfo: ExceptionInfo[BaseException], style: Optional["_TracebackStyle"] = None
     ) -> Union[str, TerminalRepr]:
-        if excinfo.errisinstance(SystemExit):
+        if isinstance(excinfo.value, SystemExit):
             # We assume that before doing exit() (which raises SystemExit) we've printed
             # enough context about what happened so that a stack trace is not useful.
             # In particular, uncaught exceptions during semantic analysis or type checking
             # call exit() and they already print out a stack trace.
             return excinfo.exconly(tryshort=True)
-        elif excinfo.errisinstance(TypecheckAssertionError):
+        elif isinstance(excinfo.value, TypecheckAssertionError):
             # with traceback removed
             exception_repr = excinfo.getrepr(style="short")
             exception_repr.reprcrash.message = ""  # type: ignore
             repr_file_location = ReprFileLocation(
-                path=self.fspath, lineno=self.starting_lineno + excinfo.value.lineno, message=""  # type: ignore
+                path=str(self.path), lineno=self.starting_lineno + excinfo.value.lineno, message=""
             )
             repr_tb_entry = TraceLastReprEntry(
                 exception_repr.reprtraceback.reprentries[-1].lines[1:], None, None, repr_file_location, "short"

--- a/pytest_mypy_plugins/tests/test_input_schema.py
+++ b/pytest_mypy_plugins/tests/test_input_schema.py
@@ -3,9 +3,9 @@ from typing import Sequence
 
 import jsonschema
 import pytest
-import yaml
 
-from pytest_mypy_plugins.collect import validate_schema
+from pytest_mypy_plugins.collect import YamlTestFile
+from pytest_mypy_plugins.definition import validate_schema
 
 
 def get_all_yaml_files(dir_path: pathlib.Path) -> Sequence[pathlib.Path]:
@@ -22,7 +22,7 @@ files = get_all_yaml_files(pathlib.Path(__file__).parent)
 
 @pytest.mark.parametrize("yaml_file", files, ids=lambda x: x.stem)
 def test_yaml_files(yaml_file: pathlib.Path) -> None:
-    validate_schema(yaml.safe_load(yaml_file.read_text()))
+    validate_schema(YamlTestFile.read_yaml_file(yaml_file))
 
 
 def test_mypy_config_is_not_an_object() -> None:
@@ -30,6 +30,7 @@ def test_mypy_config_is_not_an_object() -> None:
         validate_schema(
             [
                 {
+                    "__line__": 0,
                     "case": "mypy_config_is_not_an_object",
                     "main": "False",
                     "mypy_config": [{"force_uppercase_builtins": True}, {"force_union_syntax": True}],
@@ -47,6 +48,7 @@ def test_closed_schema() -> None:
         validate_schema(
             [
                 {
+                    "__line__": 0,
                     "case": "mypy_config_is_not_an_object",
                     "main": "False",
                     "extra_field": 1,


### PR DESCRIPTION
For https://github.com/typeddjango/pytest-mypy-plugins/issues/144 I think it'll be useful if the yaml definition can be given more control over how the test actually runs it.

To help with that this PR makes it so that the pytest entry point is less responsible for those decisions, and that there is more separation between the raw definition and the processed idea of what the test should do.

I've split this PR into many commits to make it easier to see the small changes that happen as I move code around (best seen with the github ignore whitespace option).

The notable changes include

* `File` is now defined in pytest_mypy_plugins.definition, but I've kept a reference to it from pytest_mypy_plugins.collect
* When creating the `File` objects, it dosn't default path to "main.py" because it's mandatory in the schema so it should always have a value anyways
* I made the skip logic not call eval if skip is a boolean or the strings "True" or "False"
* made test_input_schema.py use SafeLineLoader
* Changed the return annotations on the plugin entry point to be less specific as only pytest itself use them and it only cares about the more generic type
* I changed how parse_parametrized works, I don't have strong opinions if the previous implementation is preferred.