### PR TITLE
Fix internal error (#154)

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -458,7 +458,7 @@ class YamlTestItem(pytest.Item):
             repr_file_location = ReprFileLocation(
                 path=self.fspath, lineno=self.starting_lineno + excinfo.value.lineno, message=""  # type: ignore
             )
-            repr_tb_entry = TraceLastReprEntry(
+            repr_tb_entry = ReprEntry(
                 exception_repr.reprtraceback.reprentries[-1].lines[1:], None, None, repr_file_location, "short"
             )
             exception_repr.reprtraceback.reprentries = [repr_tb_entry]


### PR DESCRIPTION
As per https://github.com/typeddjango/pytest-mypy-plugins/issues/154. This at least allows pytest to function

We should really fix TraceLastReprEntry rather than use vanilla ReprEntry, I suspect (not sure what extra facility it offers, mind you?), but not sure what the issue is yet.