### PR TITLE
Tighten regex for output assertion parsing

### DIFF
--- a/pytest_mypy_plugins/tests/test-regex-assertions.yml
+++ b/pytest_mypy_plugins/tests/test-regex-assertions.yml
@@ -54,3 +54,18 @@
   main: |
     a = 'hello'
     reveal_type(a)  # NR: .*banana.*
+
+- case: regex_against_callable_comment
+  main: |
+    def foo(bar: str, ham: int = 42) -> set[str | int]:
+      return {bar, ham}
+    reveal_type(foo)  # NR: Revealed type is "def \(bar: builtins\.str, ham: builtins\.int =\) -> .*"
+
+- case: regex_against_callable_out
+  regex: yes
+  main: |
+    def foo(bar: str, ham: int = 42) -> set[str | int]:
+      return {bar, ham}
+    reveal_type(foo)
+  out: |
+    main:3: note: Revealed type is "def \(bar: builtins\.str, ham: builtins\.int =\) -> .*"

--- a/pytest_mypy_plugins/tests/test-regex-assertions.yml
+++ b/pytest_mypy_plugins/tests/test-regex-assertions.yml
@@ -72,4 +72,4 @@
       return {bar, ham}
     reveal_type(foo)
   out: |
-    main:3: note: Revealed type is "def \(bar: builtins\.str, ham: builtins\.int =\) -> .*"
+    main:5: note: Revealed type is "def \(bar: builtins\.str, ham: builtins\.int =\) -> .*"

--- a/pytest_mypy_plugins/tests/test-regex-assertions.yml
+++ b/pytest_mypy_plugins/tests/test-regex-assertions.yml
@@ -57,14 +57,18 @@
 
 - case: regex_against_callable_comment
   main: |
-    def foo(bar: str, ham: int = 42) -> set[str | int]:
+    from typing import Set, Union
+
+    def foo(bar: str, ham: int = 42) -> Set[Union[str, int]]:
       return {bar, ham}
     reveal_type(foo)  # NR: Revealed type is "def \(bar: builtins\.str, ham: builtins\.int =\) -> .*"
 
 - case: regex_against_callable_out
   regex: yes
   main: |
-    def foo(bar: str, ham: int = 42) -> set[str | int]:
+    from typing import Set, Union
+
+    def foo(bar: str, ham: int = 42) -> Set[Union[str, int]]:
       return {bar, ham}
     reveal_type(foo)
   out: |

--- a/pytest_mypy_plugins/utils.py
+++ b/pytest_mypy_plugins/utils.py
@@ -326,7 +326,7 @@ def extract_output_matchers_from_out(out: str, params: Mapping[str, Any], regex:
     lines = render_template(out, params).split("\n")
     for line in lines:
         match = re.search(
-            r"^(?P<fname>.*):(?P<lnum>\d*): (?P<severity>.*):((?P<col>\d+):)? (?P<message>.*)$", line.strip()
+            r"^(?P<fname>.+):(?P<lnum>\d+): (?P<severity>[A-Za-z]+):((?P<col>\d+):)? (?P<message>.*)$", line.strip()
         )
         if match:
             if match.group("severity") == "E":


### PR DESCRIPTION
The `severity` group was permissive enough to also capture parts of the message text if that contained any colons. Update it to only capture (ASCII) words, and update preceding groups to match at least 1 character.

Fixes #155