### PR TITLE
Work-around pytest 8.3.0 renaming _TracebackStyle

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -6,7 +6,17 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TextIO, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    TextIO,
+    Tuple,
+    Union,
+)
 
 import py
 import pytest
@@ -26,7 +36,6 @@ from pytest_mypy_plugins.utils import (
     assert_expected_matched_actual,
     fname_to_module,
 )
-
 
 if TYPE_CHECKING:
     # pytest 8.3.0 renamed _TracebackStyle to TracebackStyle, but there is no syntax

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TextIO, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TextIO, Tuple, Union
 
 import py
 import pytest
@@ -18,9 +18,6 @@ from mypy import build
 from mypy.fscache import FileSystemCache
 from mypy.main import process_options
 
-if TYPE_CHECKING:
-    from _pytest._code.code import _TracebackStyle
-
 from pytest_mypy_plugins import configs, utils
 from pytest_mypy_plugins.collect import File, YamlTestFile
 from pytest_mypy_plugins.utils import (
@@ -29,6 +26,14 @@ from pytest_mypy_plugins.utils import (
     assert_expected_matched_actual,
     fname_to_module,
 )
+
+
+if TYPE_CHECKING:
+    # pytest 8.3.0 renamed _TracebackStyle to TracebackStyle, but there is no syntax
+    # to assert what version you have using static conditions, so it has to be
+    # manually re-defined here. Once minimum supported pytest version is >= 8.3.0,
+    # the following can be replaced with `from _pytest._code.code import TracebackStyle`
+    TracebackStyle = Literal["long", "short", "line", "no", "native", "value", "auto"]
 
 
 class TraceLastReprEntry(ReprEntry):
@@ -443,7 +448,7 @@ class YamlTestItem(pytest.Item):
         return None
 
     def repr_failure(
-        self, excinfo: ExceptionInfo[BaseException], style: Optional["_TracebackStyle"] = None
+        self, excinfo: ExceptionInfo[BaseException], style: Optional["TracebackStyle"] = None
     ) -> Union[str, TerminalRepr]:
         if excinfo.errisinstance(SystemExit):
             # We assume that before doing exit() (which raises SystemExit) we've printed


### PR DESCRIPTION
Pytest replaced the private name `_pytest._code.code._TracebackStyle` with `_pytest._code.code.TracebackStyle` in 8.3.0, a change that can't easily be accounted for when running static type checks.

Replace the imported type with one that's hard-coded locally.

Fixes #158
