### PR TITLE
Allow --mypy-testing-base to be relative by resolving execution_path before cd

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -406,7 +406,7 @@ class YamlTestItem(pytest.Item):
             ):
                 self.execute_extension_hook()
 
-            execution_path = Path(temp_dir.name)
+            execution_path = Path(temp_dir.name).absolute()
             with utils.cd(execution_path):
                 mypy_executor = MypyExecutor(
                     same_process=self.same_process,


### PR DESCRIPTION
When `--mypy-testing-base=.` it raises `FileNotFoundError: [Errno 2] No such file or directory: 'pytest-mypy-lco73n48\\mypy.ini'`.
This is because prepare_config_file() confuses under utils.cd(execution_path).