### PR TITLE
Fix leak of violations in site-packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Version history
 
+## 4.0.0
+
+### Bugfixes
+
+- *Breaking*: Errors are now ignored in site-packages by default. The `--mypy-only-local-stub` flag
+  has been removed and replaced with `--mypy-no-silence-site-packages` which can be used to restore
+  the previous behavior if needed. This change was made to avoid errors being raised when enabling
+  certain mypy options, e.g. the `explicit-override` error code or the `--disallow-subclassing-any`
+  flag, which resulted in violations due to these not being supported with the stubs provided by
+  typeshed for the standard library. In addition, this affected other error codes or flags for some
+  third-party libraries in django-stubs.
+- *Breaking*: When running in a subprocess (the default), `PYTHONPATH` is no longer set. With the
+  above change, violations would still be raised in the main module for a test case, but those that
+  were flagged in imported modules would no longer be raised. This was because these modules were
+  being added to `PYTHONPATH` which caused mypy to treat them as belonging in site-packages and not
+  as part of the first-party package. The new `--mypy-modify-pythonpath` flag can be used to revert
+  to the previous behavior if needed.
+
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,12 @@ mypy-tests:
   --mypy-extension-hook=MYPY_EXTENSION_HOOK
                         Fully qualified path to the extension hook function,
                         in case you need custom yaml keys. Has to be top-level
-  --mypy-only-local-stub
-                        mypy will ignore errors from site-packages
+  --mypy-no-silence-site-packages
+                        mypy will not silence errors from site-packages
+  --mypy-modify-pythonpath
+                        When running mypy in a subprocess, modify `PYTHONPATH`
+                        to force packages to be treated as site-packages.
+                        Incompatible with `--mypy-same-process`
   --mypy-closed-schema
                         Use closed schema to validate YAML test cases,
                         which won't allow any extra keys

--- a/pytest_mypy_plugins/collect.py
+++ b/pytest_mypy_plugins/collect.py
@@ -205,9 +205,14 @@ def pytest_addoption(parser: Parser) -> None:
         "Has to be top-level.",
     )
     group.addoption(
-        "--mypy-only-local-stub",
+        "--mypy-no-silence-site-packages",
         action="store_true",
-        help="mypy will ignore errors from site-packages",
+        help="mypy will not silence errors from site-packages",
+    )
+    group.addoption(
+        "--mypy-modify-pythonpath",
+        action="store_true",
+        help="When running mypy in a subprocess, modify `PYTHONPATH` to force packages to be treated as site-packages. Incompatible with `--mypy-same-process`",
     )
     group.addoption(
         "--mypy-closed-schema",

--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -137,17 +137,20 @@ def run_mypy_typechecking(cmd_options: List[str], stdout: TextIO, stderr: TextIO
 class MypyExecutor:
     def __init__(
         self,
+        *,
         same_process: bool,
         rootdir: Union[Path, None],
         execution_path: Path,
         environment_variables: Dict[str, Any],
         mypy_executable: str,
+        modify_pythonpath: bool,
     ) -> None:
         self.rootdir = rootdir
         self.same_process = same_process
         self.execution_path = execution_path
         self.mypy_executable = mypy_executable
         self.environment_variables = environment_variables
+        self.modify_pythonpath = modify_pythonpath
 
     def execute(self, mypy_cmd_options: List[str]) -> Tuple[int, Tuple[str, str]]:
         # Returns (returncode, (stdout, stderr))
@@ -157,8 +160,10 @@ class MypyExecutor:
             return self._typecheck_in_new_subprocess(mypy_cmd_options)
 
     def _typecheck_in_new_subprocess(self, mypy_cmd_options: List[Any]) -> Tuple[int, Tuple[str, str]]:
-        # add current directory to path
-        self._collect_python_path(self.rootdir)
+        if self.modify_pythonpath:
+            # add current directory to path
+            self._collect_python_path(self.rootdir)
+
         # adding proper MYPYPATH variable
         self._collect_mypy_path(self.rootdir)
 
@@ -263,7 +268,7 @@ class Runner:
         disable_cache: bool,
         mypy_executor: MypyExecutor,
         output_checker: OutputChecker,
-        test_only_local_stub: bool,
+        no_silence_site_packages: bool,
         incremental_cache_dir: str,
     ) -> None:
         self.files = files
@@ -273,7 +278,7 @@ class Runner:
         self.mypy_executor = mypy_executor
         self.disable_cache = disable_cache
         self.output_checker = output_checker
-        self.test_only_local_stub = test_only_local_stub
+        self.no_silence_site_packages = no_silence_site_packages
         self.incremental_cache_dir = incremental_cache_dir
 
     def run(self) -> None:
@@ -301,7 +306,7 @@ class Runner:
             "--no-pretty",
             "--hide-error-context",
         ]
-        if not self.test_only_local_stub:
+        if self.no_silence_site_packages:
             mypy_cmd_options.append("--no-silence-site-packages")
         if not self.disable_cache:
             mypy_cmd_options.extend(["--cache-dir", self.incremental_cache_dir])
@@ -338,7 +343,8 @@ class YamlTestItem(pytest.Item):
         self.additional_mypy_config = mypy_config
         self.parsed_test_data = parsed_test_data
         self.same_process = self.config.option.mypy_same_process
-        self.test_only_local_stub = self.config.option.mypy_only_local_stub
+        self.modify_pythonpath = self.config.option.mypy_modify_pythonpath
+        self.no_silence_site_packages = self.config.option.mypy_no_silence_site_packages
 
         # config parameters
         self.root_directory = self.config.option.mypy_testing_base
@@ -415,6 +421,7 @@ class YamlTestItem(pytest.Item):
                     rootdir=rootdir,
                     environment_variables=self.environment_variables,
                     mypy_executable=mypy_executable,
+                    modify_pythonpath=self.modify_pythonpath,
                 )
 
                 output_checker = OutputChecker(
@@ -429,7 +436,7 @@ class YamlTestItem(pytest.Item):
                     disable_cache=self.disable_cache,
                     mypy_executor=mypy_executor,
                     output_checker=output_checker,
-                    test_only_local_stub=self.test_only_local_stub,
+                    no_silence_site_packages=self.no_silence_site_packages,
                     incremental_cache_dir=self.incremental_cache_dir,
                 ).run()
         finally:

--- a/pytest_mypy_plugins/tests/test_site_packages.py
+++ b/pytest_mypy_plugins/tests/test_site_packages.py
@@ -1,0 +1,161 @@
+import os.path
+import site
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def test_default(tmp_path: Path) -> None:
+    make_yaml_test_file(
+        tmp_path,
+        """
+- case: test_non_test_case_files_cache_files_remain
+  mypy_config: |
+    strict=true
+  main: |
+    import subpkg
+
+    a: str
+    a / 2
+  files:
+    - path: subpkg.py
+      content: |
+        a: str
+        a / 2
+  out: |
+    main:4: error: Unsupported operand types for / ("str" and "int")  [operator]
+    subpkg:2: error: Unsupported operand types for / ("str" and "int")  [operator]
+        """,
+    )
+    res = subprocess.run(
+        [
+            "pytest",
+            f"--mypy-testing-base={tmp_path}",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    assert res.returncode == pytest.ExitCode.OK
+
+
+def test_modify_pythonpath_only(tmp_path: Path) -> None:
+    make_yaml_test_file(
+        tmp_path,
+        """
+- case: test_non_test_case_files_cache_files_remain
+  mypy_config: |
+    strict=true
+  main: |
+    import subpkg
+
+    a: str
+    a / 2
+  files:
+    - path: subpkg.py
+      content: |
+        a: str
+        a / 2  # Modifying `PYTHONPATH` causes this to not raise an error as expected.
+  out: |
+    main:4: error: Unsupported operand types for / ("str" and "int")  [operator]
+        """,
+    )
+    res = subprocess.run(
+        [
+            "pytest",
+            f"--mypy-testing-base={tmp_path}",
+            "--mypy-modify-pythonpath",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    assert res.returncode == pytest.ExitCode.OK
+
+
+def test_no_silence_site_packages_only(tmp_path: Path) -> None:
+    make_yaml_test_file(
+        tmp_path,
+        """
+- case: test_non_test_case_files_cache_files_remain
+  mypy_config: |
+    strict=true
+  main: |
+    import subpkg
+
+    a: str
+    a / 2
+  files:
+    - path: subpkg.py
+      content: |
+        a: str
+        a / 2
+  out: |
+    {site_packages_path}/mypy/typeshed/stdlib/types.pyi:721: error: Class cannot subclass "Any" (has type "Any")  [misc]
+    main:4: error: Unsupported operand types for / ("str" and "int")  [operator]
+    subpkg:2: error: Unsupported operand types for / ("str" and "int")  [operator]
+        """,
+    )
+    res = subprocess.run(
+        [
+            "pytest",
+            f"--mypy-testing-base={tmp_path}",
+            "--mypy-no-silence-site-packages",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    assert res.returncode == pytest.ExitCode.OK
+
+
+def test_no_silence_site_packages_and_modify_pythonpath(tmp_path: Path) -> None:
+    make_yaml_test_file(
+        tmp_path,
+        """
+- case: test_non_test_case_files_cache_files_remain
+  mypy_config: |
+    strict=true
+  main: |
+    import subpkg
+
+    a: str
+    a / 2
+  files:
+    - path: subpkg.py
+      content: |
+        a: str
+        a / 2
+  out: |
+    {site_packages_path}/mypy/typeshed/stdlib/types.pyi:721: error: Class cannot subclass "Any" (has type "Any")  [misc]
+    main:4: error: Unsupported operand types for / ("str" and "int")  [operator]
+    subpkg:2: error: Unsupported operand types for / ("str" and "int")  [operator]
+        """,
+    )
+    res = subprocess.run(
+        [
+            "pytest",
+            f"--mypy-testing-base={tmp_path}",
+            "--mypy-no-silence-site-packages",
+            "--mypy-modify-pythonpath",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    assert res.returncode == pytest.ExitCode.OK
+
+
+def make_yaml_test_file(
+    root_dir: Path,
+    contents: str,
+    /,
+    *,
+    file_base_name: str = "test-case",
+) -> None:
+    output_path = root_dir.joinpath(file_base_name).with_suffix(".yml")
+    site_packages_path: Path | str = Path(site.getsitepackages()[0])
+    site_packages_path = os.path.relpath(site_packages_path, start=output_path)
+    contents = contents.format(site_packages_path=site_packages_path)
+    output_path.write_text(contents)


### PR DESCRIPTION
Makes the following changes to avoid third-party packages being treated as first-party packages which causes errors to be raised where those packages violate settings for mypy that are enabled in the stubs package:

- Don't use `--no-silence-site-packages` by default
- Don't add the test root path to `PYTHONPATH`

Flags have been added that allow reverting to the previous behavior in case there are users of this plugin that depend on that behavior.

Fixes #134