### PR TITLE
Include test case name in temp directory prefix

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -394,7 +394,7 @@ class YamlTestItem(pytest.Item):
 
     def runtest(self) -> None:
         try:
-            temp_dir = tempfile.TemporaryDirectory(prefix="pytest-mypy-", dir=self.root_directory)
+            temp_dir = tempfile.TemporaryDirectory(prefix=f"pytest-mypy-{self.name}-", dir=self.root_directory)
 
         except (FileNotFoundError, PermissionError, NotADirectoryError) as e:
             raise TypecheckAssertionError(


### PR DESCRIPTION
This helps avoids potential mypy cache contamination when multiple tests use the same module names.

See https://github.com/typeddjango/django-stubs/pull/3299#issuecomment-4235148896 for context