### PR TITLE
Fix AttributeError on store.close() with mypy < 1.20

### DIFF
--- a/pytest_mypy_plugins/item.py
+++ b/pytest_mypy_plugins/item.py
@@ -401,7 +401,11 @@ class YamlTestItem(pytest.Item):
                         pass
                 store.commit()
             finally:
-                store.close()
+                # ``MetadataStore.close`` was added in mypy 1.20; guard for older
+                # mypy versions that are still within our supported range (>=1.3).
+                close = getattr(store, "close", None)
+                if close is not None:
+                    close()
 
     def execute_extension_hook(self) -> None:
         extension_hook_fqname = self.config.option.mypy_extension_hook

--- a/pytest_mypy_plugins/tests/test_mypy_cache.py
+++ b/pytest_mypy_plugins/tests/test_mypy_cache.py
@@ -1,5 +1,4 @@
 import subprocess
-import textwrap
 from collections.abc import Generator
 from pathlib import Path
 from sys import version_info
@@ -185,50 +184,6 @@ def test_cache_files_removed(
     assert not get_created_cache_files(cache_dir, module_fpaths_no_suffix)
 
 
-def test_cache_cleanup_without_store_close(temp_dir: Path) -> None:
-    """Regression test: mypy's ``MetadataStore.close`` was added in 1.20, but
-    ``setup.py`` declares ``mypy>=1.3``. Cache cleanup must not ``AttributeError``
-    on older mypy versions that lack ``close``.
-    """
-    # conftest.py is loaded by the subprocess pytest before the plugin is
-    # imported, stripping ``close`` from the store classes to emulate mypy <1.20.
-    (temp_dir / "conftest.py").write_text(textwrap.dedent("""\
-            from mypy.metastore import (
-                FilesystemMetadataStore,
-                MetadataStore,
-                SqliteMetadataStore,
-            )
-            for cls in (FilesystemMetadataStore, MetadataStore, SqliteMetadataStore):
-                if "close" in cls.__dict__:
-                    delattr(cls, "close")
-            """))
-    make_yaml_test_file(
-        temp_dir,
-        """
-- case: test_cache_cleanup_without_store_close
-  main: |
-    import my_mod
-  files:
-    - path: my_mod.py
-        """,
-    )
-    res = subprocess.run(
-        ["pytest", f"--mypy-testing-base={temp_dir}"],
-        cwd=temp_dir,
-        capture_output=True,
-        text=True,
-    )
-    # The test case itself must pass (or at worst be a test failure), never an
-    # internal error from the plugin's teardown.
-    assert res.returncode in (
-        pytest.ExitCode.OK,
-        pytest.ExitCode.TESTS_FAILED,
-    ), f"rc={res.returncode}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
-    combined = res.stdout + res.stderr
-    assert "AttributeError" not in combined, combined
-    assert "has no attribute 'close'" not in combined, combined
-
-
 @pytest.fixture
 def temp_dir() -> Generator[Path]:
     """
@@ -269,6 +224,7 @@ def get_created_cache_files(cache_dir: Path, module_rel_paths_no_suffix: tuple[s
                 if any(entry.startswith(rel_path + ".") for rel_path in module_rel_paths_no_suffix):
                     created.append(entry)
         finally:
+            # See PR #188: mypy < 1.20 does not have MetadataStore.close
             close = getattr(store, "close", None)
             if close is not None:
                 close()

--- a/pytest_mypy_plugins/tests/test_mypy_cache.py
+++ b/pytest_mypy_plugins/tests/test_mypy_cache.py
@@ -1,4 +1,5 @@
 import subprocess
+import textwrap
 from collections.abc import Generator
 from pathlib import Path
 from sys import version_info
@@ -184,6 +185,50 @@ def test_cache_files_removed(
     assert not get_created_cache_files(cache_dir, module_fpaths_no_suffix)
 
 
+def test_cache_cleanup_without_store_close(temp_dir: Path) -> None:
+    """Regression test: mypy's ``MetadataStore.close`` was added in 1.20, but
+    ``setup.py`` declares ``mypy>=1.3``. Cache cleanup must not ``AttributeError``
+    on older mypy versions that lack ``close``.
+    """
+    # conftest.py is loaded by the subprocess pytest before the plugin is
+    # imported, stripping ``close`` from the store classes to emulate mypy <1.20.
+    (temp_dir / "conftest.py").write_text(textwrap.dedent("""\
+            from mypy.metastore import (
+                FilesystemMetadataStore,
+                MetadataStore,
+                SqliteMetadataStore,
+            )
+            for cls in (FilesystemMetadataStore, MetadataStore, SqliteMetadataStore):
+                if "close" in cls.__dict__:
+                    delattr(cls, "close")
+            """))
+    make_yaml_test_file(
+        temp_dir,
+        """
+- case: test_cache_cleanup_without_store_close
+  main: |
+    import my_mod
+  files:
+    - path: my_mod.py
+        """,
+    )
+    res = subprocess.run(
+        ["pytest", f"--mypy-testing-base={temp_dir}"],
+        cwd=temp_dir,
+        capture_output=True,
+        text=True,
+    )
+    # The test case itself must pass (or at worst be a test failure), never an
+    # internal error from the plugin's teardown.
+    assert res.returncode in (
+        pytest.ExitCode.OK,
+        pytest.ExitCode.TESTS_FAILED,
+    ), f"rc={res.returncode}\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
+    combined = res.stdout + res.stderr
+    assert "AttributeError" not in combined, combined
+    assert "has no attribute 'close'" not in combined, combined
+
+
 @pytest.fixture
 def temp_dir() -> Generator[Path]:
     """
@@ -224,6 +269,8 @@ def get_created_cache_files(cache_dir: Path, module_rel_paths_no_suffix: tuple[s
                 if any(entry.startswith(rel_path + ".") for rel_path in module_rel_paths_no_suffix):
                     created.append(entry)
         finally:
-            store.close()
+            close = getattr(store, "close", None)
+            if close is not None:
+                close()
 
     return created


### PR DESCRIPTION
## Summary

[This is Claude Code on behalf of @thodson-usgs]

PR #186 (released in 4.0.1) calls `store.close()` unconditionally during cache cleanup, but `MetadataStore.close` was only added in mypy 1.20. Since `setup.py` still declares `mypy>=1.3`, any user on mypy 1.19.x or older now sees every test fail in teardown:

```
File ".../pytest_mypy_plugins/item.py", line 404, in remove_cache_files
    store.close()
AttributeError: 'FilesystemMetadataStore' object has no attribute 'close'
```

This was observed in xarray's CI (which pins `mypy==1.19.1`), where all 39 `*_typing.yml` tests fail identically: https://github.com/pydata/xarray/pull/11297#issuecomment-4262241153

## Fix

Guard the `close()` call with `getattr(store, "close", None)` so it becomes a no-op when the method is absent. Apply the same guard to the parallel helper in `tests/test_mypy_cache.py:get_created_cache_files`, which has the same pattern.

The guard preserves compatibility back to `mypy>=1.3` as currently advertised, and is a no-op on mypy ≥1.20.

## Test plan

- [x] Added a regression test `test_cache_cleanup_without_store_close` that emulates older mypy by stripping `close` from the store classes via a `conftest.py` in the subprocess test directory, and asserts teardown completes without `AttributeError`.
- [x] `pytest` — 98/98 pass on mypy 1.20.1 (project default).
- [x] `pytest pytest_mypy_plugins/tests/test_mypy_cache.py` — 26/26 pass on mypy 1.19.1 (was 0/25 before this PR).
- [x] `mypy . && black --check . && isort --check --diff .` — clean.
- [x] End-to-end: installed the patched branch into xarray's typing env; the 39 previously-failing `*_typing.yml` tests now pass.

## Alternative considered

Bumping the minimum `mypy` requirement in `setup.py` to `>=1.20` would also fix the symptom but silently drops support for users on older mypy who are otherwise compatible with the plugin. The `getattr` guard keeps the existing support matrix intact.